### PR TITLE
Optimising pagination logic and limit number of pages return

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -1,0 +1,40 @@
+name: Publish docker image
+
+on:
+    push:
+      tags:
+        - '*'
+
+jobs:
+  push_to_registry:
+    name: Push image to docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Get Tags for cloud-platform-concourse-github-pr-resource Image
+        id: metadata-tools
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        with:
+          images: ministryofjustice/cloud-platform-concourse-github-pr-resource
+          tags: |
+            type=ref,event=tag
+    
+      - name: Build and push cloud-platform-concourse-github-pr-resource image
+        uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ github.ref_name }}
+      

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 vars:
   BUILD_DIR: build

--- a/github.go
+++ b/github.go
@@ -18,6 +18,7 @@ import (
 )
 
 // Github for testing purposes.
+//
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o fakes/fake_github.go . Github
 type Github interface {
 	ListPullRequests([]githubv4.PullRequestState) ([]*PullRequest, error)
@@ -125,17 +126,19 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([
 					}
 				}
 				PageInfo struct {
-					EndCursor   githubv4.String
-					HasNextPage bool
+					EndCursor       githubv4.String
+					HasNextPage     bool
+					StartCursor     githubv4.String // StartCursor for reverse pagination
+					HasPreviousPage bool            // HasPreviousPage for reverse pagination
 				}
-			} `graphql:"pullRequests(first:$prFirst,states:$prStates,after:$prCursor)"`
+			} `graphql:"pullRequests(last:$prLast,states:$prStates,before:$prCursor, orderBy: {field: UPDATED_AT, direction: ASC})"`
 		} `graphql:"repository(owner:$repositoryOwner,name:$repositoryName)"`
 	}
 
 	vars := map[string]interface{}{
 		"repositoryOwner": githubv4.String(m.Owner),
 		"repositoryName":  githubv4.String(m.Repository),
-		"prFirst":         githubv4.Int(100),
+		"prLast":          githubv4.Int(100),
 		"prStates":        prStates,
 		"prCursor":        (*githubv4.String)(nil),
 		"commitsLast":     githubv4.Int(1),
@@ -144,6 +147,7 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([
 	}
 
 	var response []*PullRequest
+	pageCount := 0 // Counter to track the number of pages fetched
 	for {
 		if err := m.V4.Query(context.TODO(), &query, vars); err != nil {
 			return nil, err
@@ -163,10 +167,13 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([
 				})
 			}
 		}
-		if !query.Repository.PullRequests.PageInfo.HasNextPage {
-			break
+
+		// Increment the page counter
+		pageCount++
+		if pageCount >= 3 || !query.Repository.PullRequests.PageInfo.HasPreviousPage {
+			break // Stop fetching after 3 pages or if there are no more pages
 		}
-		vars["prCursor"] = query.Repository.PullRequests.PageInfo.EndCursor
+		vars["prCursor"] = query.Repository.PullRequests.PageInfo.StartCursor
 	}
 	return response, nil
 }


### PR DESCRIPTION
Optimising pagination logic and limit number of pages return to avoid hitting GraphQL API limits.

Previously when PR check was ran against the environments repo, the check would hit GraphQL API limits causing the check to timeout, as the repo has ~30k PRs. This change now introduces logic to only check the last 300 PRs.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/5566